### PR TITLE
Fix issue with editability and color in multi select dropdowns

### DIFF
--- a/projects/ngx-grid-core/package-lock.json
+++ b/projects/ngx-grid-core/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ngx-grid-core",
-  "version": "0.7.6",
+  "version": "0.7.7",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ngx-grid-core",
-      "version": "0.7.6",
+      "version": "0.7.7",
       "dependencies": {
         "tslib": "^2.3.0"
       },

--- a/projects/ngx-grid-core/package.json
+++ b/projects/ngx-grid-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blueshiftone/ngx-grid-core",
-  "version": "0.7.6",
+  "version": "0.7.7",
   "repository": {
     "type": "git",
     "url": "https://github.com/blueshiftone/ngx-grid",

--- a/projects/ngx-grid-core/src/lib/ui/cell/cell-types/dropdown-multi-select.cell-type.ts
+++ b/projects/ngx-grid-core/src/lib/ui/cell/cell-types/dropdown-multi-select.cell-type.ts
@@ -19,6 +19,7 @@ private readonly readonlyCssClassName = 'multi-select-readonly'
 
   private _displayNode?: HTMLElement
   private _editableNode?: HTMLElement
+  public defaultColor = `rgba(255, 136, 0, 0.4)`
 
   constructor(
     gridController: GridControllerService,
@@ -61,7 +62,7 @@ private readonly readonlyCssClassName = 'multi-select-readonly'
     return output.join('\n')
   }
 
-  private _createChip(txt: string | number, color?: string): string {
+  private _createChip(txt: string | number, color: string = this.defaultColor): string {
     let chipStyles: string[]  = []
     let chipClasses: string[] = []
     

--- a/projects/ngx-grid-core/src/lib/ui/cell/cell-types/styles/cell-type-styles.scss
+++ b/projects/ngx-grid-core/src/lib/ui/cell/cell-types/styles/cell-type-styles.scss
@@ -153,7 +153,6 @@ input[type="number"] {
   overflow: hidden;
   .chip {
     margin-right: 4px;
-    background-color: rgba($color: rgb(255, 136, 0), $alpha: 0.4);
     &:last-child {
       margin-right: 0px;
     }

--- a/projects/ngx-grid-core/src/lib/ui/grid-overlays/base-grid-overlay.component.ts
+++ b/projects/ngx-grid-core/src/lib/ui/grid-overlays/base-grid-overlay.component.ts
@@ -9,7 +9,7 @@ import { AutoUnsubscribe } from '../../utils/auto-unsubscribe'
 })
 export class BaseOverlayComponent extends AutoUnsubscribe implements OnInit {
 
-  public editable: boolean = true
+  public get editable() { return this.cell.isEditable }
   public value   : any
 
   constructor(

--- a/projects/ngx-grid-core/src/lib/ui/grid-overlays/file-grid-cell-preview-overlay/file-grid-cell-preview-overlay.component.html
+++ b/projects/ngx-grid-core/src/lib/ui/grid-overlays/file-grid-cell-preview-overlay/file-grid-cell-preview-overlay.component.html
@@ -9,7 +9,7 @@
         [style.background]="'conic-gradient(var(--text-color) '+(upload.progress | async)+'%, transparent 0)'"></div>
       <div class="progressTxt">{{ upload.progress | async }}%</div>
     </data-grid-chip>
-    <data-grid-chip [color]="chipColor" [editable]="cell.isEditable" [theme]="themeMode" *ngFor="let file of files"
+    <data-grid-chip [color]="chipColor" [editable]="editable" [theme]="themeMode" *ngFor="let file of files"
       [label]="file.fileName" (removeAction)="remove(file)" (clickAction)="requestDownload(file)">
       <mat-icon svgIcon="Paperclip"></mat-icon>
     </data-grid-chip>

--- a/projects/ngx-grid-core/src/lib/ui/grid-overlays/multi-select-grid-cell-preview/multi-select-grid-cell-preview.component.html
+++ b/projects/ngx-grid-core/src/lib/ui/grid-overlays/multi-select-grid-cell-preview/multi-select-grid-cell-preview.component.html
@@ -1,6 +1,6 @@
 <data-grid-expandable-preview-popup (action)="$event === 'expandButton' || !editable ? expand() : select()"
   [overlayData]="data">
-  <data-grid-chip [color]="defaultColor" [theme]="themeMode" [editable]="cell.isEditable" *ngFor="let chip of chips"
+  <data-grid-chip [color]="defaultColor" [theme]="themeMode" [editable]="editable" *ngFor="let chip of chips"
     [label]="chip.label" (removeAction)="remove(chip.value)"></data-grid-chip>
   <data-grid-cell-action-button actionType="more" (action)="expand()" *ngIf="totalChipCount > 2">
   </data-grid-cell-action-button>

--- a/projects/ngx-grid-core/src/lib/ui/grid-overlays/multi-select-grid-cell-preview/multi-select-grid-cell-preview.component.ts
+++ b/projects/ngx-grid-core/src/lib/ui/grid-overlays/multi-select-grid-cell-preview/multi-select-grid-cell-preview.component.ts
@@ -7,6 +7,7 @@ import { EGridOverlayType } from '../../../typings/enums/grid-overlay-type.enum'
 import { IGridOverlayData } from '../../../typings/interfaces'
 import { TPrimaryKey } from '../../../typings/types'
 import { DeleteFromArray } from '../../../utils/array-delete'
+import { DropdownMultiSelectCellType } from '../../cell/cell-types/dropdown-multi-select.cell-type'
 import { BasePreviewComponent } from '../base-grid-preview-overlay.component'
 
 @Component({
@@ -98,7 +99,7 @@ export class MultiSelectGridCellPreviewComponent extends BasePreviewComponent im
   }
 
   public get defaultColor(): string | undefined {
-    return this.data.currentCell.type.list?.color
+    return this.data.currentCell.type.list?.color ?? (this.data.currentCell as DropdownMultiSelectCellType).defaultColor
   }
 
 }

--- a/projects/ngx-grid-core/src/lib/ui/grid-overlays/multi-select-grid-selected-list/multi-select-grid-selected-list.component.scss
+++ b/projects/ngx-grid-core/src/lib/ui/grid-overlays/multi-select-grid-selected-list/multi-select-grid-selected-list.component.scss
@@ -8,9 +8,6 @@
   height: 100%;
   display: block;
   overflow: hidden;
-  &:not(.editable) {
-    pointer-events: none;
-  }
   .grid {
     border-top: 1px solid var(--divider-color);
     border-right: 1px solid var(--divider-color);

--- a/projects/ngx-grid-core/src/lib/ui/grid-overlays/multi-select-static-cell-preview/multi-select-static-cell-preview.component.html
+++ b/projects/ngx-grid-core/src/lib/ui/grid-overlays/multi-select-static-cell-preview/multi-select-static-cell-preview.component.html
@@ -1,10 +1,10 @@
 <data-grid-expandable-preview-popup (action)="$event === 'expandButton' ? expand() : select()" [overlayData]="data">
-  <data-grid-chip chipStyle="rounded" [color]="option.color ?? defaultColor" [editable]="cell.isEditable"
+  <data-grid-chip chipStyle="rounded" [color]="option.color ?? defaultColor" [editable]="editable"
     [theme]="themeMode" *ngFor="let option of options" [label]="option.label ?? option.value?.toString()"
     (removeAction)="remove(option)">
   </data-grid-chip>
   <data-grid-cell-action-button actionType="more" (action)="expand()" *ngIf="totalOptionsCount > 2">
   </data-grid-cell-action-button>
-  <data-grid-cell-action-button actionType="add" (action)="select()" *ngIf="cell.isEditable">
+  <data-grid-cell-action-button actionType="add" (action)="select()" *ngIf="editable">
   </data-grid-cell-action-button>
 </data-grid-expandable-preview-popup>

--- a/projects/ngx-grid-core/src/lib/ui/grid-overlays/multi-select-static-list-overlay/multi-select-static-list-overlay.component.html
+++ b/projects/ngx-grid-core/src/lib/ui/grid-overlays/multi-select-static-list-overlay/multi-select-static-list-overlay.component.html
@@ -1,11 +1,11 @@
 <app-floating-window (closed)="close()">
-  <div class="actions" [style.marginBottom]="options?.length ? '14px' : ''" *ngIf="cell.isEditable">
+  <div class="actions" [style.marginBottom]="options?.length ? '14px' : ''" *ngIf="editable">
     <button mat-button color="primary" (click)="select()" class="link" #AddBtn>
       <span class="material-symbols-outlined">add</span>
       <span class="label">{{ localize('locSelectAnOption') }}</span>
     </button>
   </div>
-  <data-grid-chip [color]="option.color ?? defaultColor" [editable]="cell.isEditable" [theme]="themeMode"
+  <data-grid-chip [color]="option.color ?? defaultColor" [editable]="editable" [theme]="themeMode"
     *ngFor="let option of options" [label]="option.label ?? option.value?.toString()" (removeAction)="remove(option)"
     chipStyle="rounded"></data-grid-chip>
 </app-floating-window>


### PR DESCRIPTION
Multi-select dropdowns are now applying read-only state correctly and consistently applying background color in preview overlay.