### PR TITLE
Grid filtering changes and bugfixes

### DIFF
--- a/projects/ngx-grid-core/package-lock.json
+++ b/projects/ngx-grid-core/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ngx-grid-core",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ngx-grid-core",
-      "version": "0.13.0",
+      "version": "0.14.0",
       "dependencies": {
         "tslib": "^2.3.0"
       },

--- a/projects/ngx-grid-core/package.json
+++ b/projects/ngx-grid-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blueshiftone/ngx-grid-core",
-  "version": "0.13.0",
+  "version": "0.14.0",
   "repository": {
     "type": "git",
     "url": "https://github.com/blueshiftone/ngx-grid",

--- a/projects/ngx-grid-core/src/lib/controller/cell-operations/get-formated-value.operation.ts
+++ b/projects/ngx-grid-core/src/lib/controller/cell-operations/get-formated-value.operation.ts
@@ -11,57 +11,61 @@ export class GetFormattedValue extends Operation {
 
   public getPlainText(coords: IGridCellCoordinates, value?: any): string
   public getPlainText(column: IGridColumn, value?: any): string
-  public getPlainText(arg1: IGridCellCoordinates | IGridColumn, value?: any): string
+  public getPlainText(coordsOrColumn: IGridCellCoordinates | IGridColumn, value?: any): string
   {
-    return this._handleOverload(arg1, value, false)
+    return this._handleOverload(coordsOrColumn, value, false)
   }
 
   public getHTML(coords: IGridCellCoordinates, value?: any): string
   public getHTML(column: IGridColumn, value?: any): string
-  public getHTML(arg1: IGridCellCoordinates | IGridColumn, value?: any): string
+  public getHTML(coordsOrColumn: IGridCellCoordinates | IGridColumn, value?: any): string
   {
-    return this._handleOverload(arg1, value, true)
+    return this._handleOverload(coordsOrColumn, value, true)
   }
 
-  private _isCoordinates(arg: IGridCellCoordinates | IGridColumn): arg is IGridCellCoordinates {
-    return arg.hasOwnProperty('rowKey')
+  private _isCoordinates(coordsOrColumn: IGridCellCoordinates | IGridColumn): coordsOrColumn is IGridCellCoordinates {
+    return coordsOrColumn.hasOwnProperty('rowKey')
   }
 
-  private _isColumn(arg: IGridCellCoordinates | IGridColumn): arg is IGridColumn {
-    return arg.hasOwnProperty('columnKey') && arg.hasOwnProperty('dropdownMenu')
+  private _isColumn(coordsOrColumn: IGridCellCoordinates | IGridColumn): coordsOrColumn is IGridColumn {
+    return coordsOrColumn.hasOwnProperty('columnKey') && coordsOrColumn.hasOwnProperty('dropdownMenu')
   }
 
-  private _handleOverload(input: IGridCellCoordinates | IGridColumn, value: any, html: boolean): string {
-    if (this._isColumn(input)) {
-      return this._run(input, value, html)
-    } else if (this._isCoordinates(input)) {
-      return this._run(input, value, html)
+  private _handleOverload(coordsOrColumn: IGridCellCoordinates | IGridColumn, value: any, html: boolean): string {
+    if (this._isColumn(coordsOrColumn)) {
+      return this._run(coordsOrColumn, value, html)
+    } else if (this._isCoordinates(coordsOrColumn)) {
+      return this._run(coordsOrColumn, value, html)
     }
     throw new Error('Invalid argument')
   }
 
   private _run(coords: IGridCellCoordinates, value: any, returnHtml: boolean): string
   private _run(column: IGridColumn, value: any, returnHtml: boolean): string
-  private _run(arg1: IGridCellCoordinates | IGridColumn, value: any, returnHtml: boolean): string
+  private _run(coordsOrColumn: IGridCellCoordinates | IGridColumn, value: any, returnHtml: boolean): string
   {
     
     let dataType: IGridDataType = { name: 'Text' }
 
     let formatString: string | null = null
 
-    if (this._isColumn(arg1)) { // is IGridColumn
+    if (this._isColumn(coordsOrColumn)) { // is IGridColumn
+
+      const column = coordsOrColumn
       
-      dataType = arg1.type ?? dataType
+      dataType = column.type ?? dataType
 
-      formatString = arg1.metadata.get(EMetadataType.NumberFormatString)
+      formatString = column.metadata.get(EMetadataType.NumberFormatString)
 
-    } else if (this._isCoordinates(arg1)) { // is IGridCellCoordinates
+    } else if (this._isCoordinates(coordsOrColumn)) { // is IGridCellCoordinates
 
-      value = value ?? this.cellOperations.GetCellValue.run(arg1)?.value
+      const coords = coordsOrColumn
 
-      dataType = this.cellOperations.GetCellType.run(arg1)
+      value = value ?? this.cellOperations.GetCellValue.run(coords)?.value
 
-      formatString = this.cellOperations.GetCellMetaValue.run<string>(arg1, EMetadataType.NumberFormatString)
+      dataType = this.cellOperations.GetCellType.run(coords)
+
+      formatString = this.cellOperations.GetCellMetaValue.run<string>(coords, EMetadataType.NumberFormatString)
 
     }
     

--- a/projects/ngx-grid-core/src/lib/controller/cell-operations/get-formated-value.operation.ts
+++ b/projects/ngx-grid-core/src/lib/controller/cell-operations/get-formated-value.operation.ts
@@ -1,5 +1,5 @@
 import { EMetadataType } from '../../typings/enums'
-import { IGridCellCoordinates } from '../../typings/interfaces'
+import { IGridCellCoordinates, IGridColumn, IGridDataType } from '../../typings/interfaces'
 import { ICellOperationFactory } from '../../typings/interfaces/grid-cell-operation-factory.interface'
 import { NumberFormatParser } from '../../utils/number-format-parser/number-format-parser'
 import { ParseDate } from '../../utils/parse-date-string'
@@ -9,14 +9,67 @@ export class GetFormattedValue extends Operation {
 
   constructor(factory: ICellOperationFactory) { super(factory.gridController) }
 
-  public run(coords: IGridCellCoordinates, value?: any, returnHtml = true): string {
-    value = value ?? this.cellOperations.GetCellValue.run(coords)?.value
-    if (value === null || value === undefined) return ''
-    const cellType = this.cellOperations.GetCellType.run(coords)
-    switch (cellType.name) {
+  public getPlainText(coords: IGridCellCoordinates, value?: any): string
+  public getPlainText(column: IGridColumn, value?: any): string
+  public getPlainText(arg1: IGridCellCoordinates | IGridColumn, value?: any): string
+  {
+    return this._handleOverload(arg1, value, false)
+  }
+
+  public getHTML(coords: IGridCellCoordinates, value?: any): string
+  public getHTML(column: IGridColumn, value?: any): string
+  public getHTML(arg1: IGridCellCoordinates | IGridColumn, value?: any): string
+  {
+    return this._handleOverload(arg1, value, true)
+  }
+
+  private _isCoordinates(arg: IGridCellCoordinates | IGridColumn): arg is IGridCellCoordinates {
+    return arg.hasOwnProperty('rowKey')
+  }
+
+  private _isColumn(arg: IGridCellCoordinates | IGridColumn): arg is IGridColumn {
+    return arg.hasOwnProperty('columnKey') && arg.hasOwnProperty('dropdownMenu')
+  }
+
+  private _handleOverload(input: IGridCellCoordinates | IGridColumn, value: any, html: boolean): string {
+    if (this._isColumn(input)) {
+      return this._run(input, value, html)
+    } else if (this._isCoordinates(input)) {
+      return this._run(input, value, html)
+    }
+    throw new Error('Invalid argument')
+  }
+
+  private _run(coords: IGridCellCoordinates, value: any, returnHtml: boolean): string
+  private _run(column: IGridColumn, value: any, returnHtml: boolean): string
+  private _run(arg1: IGridCellCoordinates | IGridColumn, value: any, returnHtml: boolean): string
+  {
+    
+    let dataType: IGridDataType = { name: 'Text' }
+
+    let formatString: string | null = null
+
+    if (this._isColumn(arg1)) { // is IGridColumn
+      
+      dataType = arg1.type ?? dataType
+
+      formatString = arg1.metadata.get(EMetadataType.NumberFormatString)
+
+    } else if (this._isCoordinates(arg1)) { // is IGridCellCoordinates
+
+      value = value ?? this.cellOperations.GetCellValue.run(arg1)?.value
+
+      dataType = this.cellOperations.GetCellType.run(arg1)
+
+      formatString = this.cellOperations.GetCellMetaValue.run<string>(arg1, EMetadataType.NumberFormatString)
+
+    }
+    
+    if (value === null || value === undefined) return ''    
+    
+    switch (dataType.name) {
       case 'NumberRange':
       case 'Number':
-        let formatString = this.cellOperations.GetCellMetaValue.run<string>(coords, EMetadataType.NumberFormatString)
         if (formatString) {
           if (!returnHtml) {
             // Remove spacer chars from format string
@@ -50,12 +103,12 @@ export class GetFormattedValue extends Operation {
         if (typeof value === 'object' && value !== null && value.fileName !== undefined) return value.fileName
         break
       case 'DropdownSingleSelect':
-        const gridId = cellType.list?.relatedGridID
-        if (gridId) this.gridOperations.GetRelatedDataPreviewString.run(gridId, value)
+        const gridId = dataType.list?.relatedGridID
+        if (gridId) return this.gridOperations.GetRelatedDataPreviewString.run(gridId, value)
         break
       case 'DropdownMultiSelect':
         if (Array.isArray(value)) {
-          const gridId = cellType.list?.relatedGridID
+          const gridId = dataType.list?.relatedGridID
           if (gridId) return value.map(v => this.gridOperations.GetRelatedDataPreviewString.run(gridId, v)).join(', ')
         }
         break
@@ -70,8 +123,7 @@ export class GetFormattedValue extends Operation {
   }
 
   private get _dateFormat(): string {
-    const format = this.gridOperations.gridController.localize.getLocalizedString('dateFormat')
-    return format === 'dateFormat' ? this.gridOperations.gridController.defaultDateFormat : format
+    return this.gridOperations.gridController.getDateFormat()
   }
 
 }

--- a/projects/ngx-grid-core/src/lib/controller/grid-controller.service.ts
+++ b/projects/ngx-grid-core/src/lib/controller/grid-controller.service.ts
@@ -241,4 +241,9 @@ export class GridControllerService {
     })
   }
 
+  public getDateFormat() {
+    const format = this.localize.getLocalizedString('dateFormat')
+    return format === 'dateFormat' ? this.defaultDateFormat : format
+  }
+
 }

--- a/projects/ngx-grid-core/src/lib/controller/grid-operations/viewport-scroll-to-coordinates.operation.ts
+++ b/projects/ngx-grid-core/src/lib/controller/grid-operations/viewport-scroll-to-coordinates.operation.ts
@@ -31,7 +31,7 @@ export class ViewportScrollToCoordinates extends Operation {
   private _scrollTo(cellPos: IGridCellCoordinates) {
     const { viewPort } = this.gridOperations
     if (!viewPort) return
-    const utils              = GridImplementationFactory.gridSelectionRange(this.gridEvents).globalUtils
+    const utils              = GridImplementationFactory.gridSelectionRange(this.gridOperations.gridController).globalUtils
     const maxItemsInViewport = Math.floor(viewPort.getViewportSize() / 25) -2
     const firstVisibleIndex  = Math.floor(viewPort.measureScrollOffset('top') / 25) + 1
     const lastVisibleIndex   = firstVisibleIndex + maxItemsInViewport -1

--- a/projects/ngx-grid-core/src/lib/controller/selection/operations/add-secondary-selection.operation.ts
+++ b/projects/ngx-grid-core/src/lib/controller/selection/operations/add-secondary-selection.operation.ts
@@ -14,7 +14,7 @@ export class AddSecondarySelection extends BaseSelectionOperation {
     const state = this.selectionState
     if (!state) return
     selection = selection ?? state.currentSelection
-    selection.secondarySelection = GridImplementationFactory.gridSelectionRange(this.controller.gridEvents).addRange(from ?? state.startCellPos, to ?? state.endCellPos)
+    selection.secondarySelection = GridImplementationFactory.gridSelectionRange(this.controller.gridController).addRange(from ?? state.startCellPos, to ?? state.endCellPos)
     selection.secondarySelection.isSubtracting = state.isSubtracting
   }
 

--- a/projects/ngx-grid-core/src/lib/controller/selection/operations/create-selection-state-from-coordinates.operation.ts
+++ b/projects/ngx-grid-core/src/lib/controller/selection/operations/create-selection-state-from-coordinates.operation.ts
@@ -11,7 +11,7 @@ export class CreateSelectionStateFromCoordinates {
     ctrlKey?: boolean,
     shiftKey?: boolean,
   ): IGridSelectionState {
-    const state = new GridSelectionStateFromCoordinates(...coordinates, this.controller.gridEvents, input, ctrlKey, shiftKey)
+    const state = new GridSelectionStateFromCoordinates(...coordinates, this.controller.gridController, input, ctrlKey, shiftKey)
     return state
   }
 

--- a/projects/ngx-grid-core/src/lib/controller/selection/operations/create-selection-state-from-mouse-event.operation.ts
+++ b/projects/ngx-grid-core/src/lib/controller/selection/operations/create-selection-state-from-mouse-event.operation.ts
@@ -32,7 +32,7 @@ export class CreateSelectionStateFromMouseEvent {
   private _getSelection()  : IGridSelectionRange            { return this._gridEvents.CellSelectionChangedEvent.state || this._newSelection() }
   private _getEditingCell(): IGridCellComponent | undefined { return this._gridEvents.EditingCellChangedEvent.state ?? undefined }
   private _getFocusedCell(): IGridCellFocused | undefined   { return this._gridEvents.CellFocusChangedEvent.state }
-  private _newSelection()  : IGridSelectionRange            { return GridImplementationFactory.gridSelectionRange(this._gridEvents) }
+  private _newSelection()  : IGridSelectionRange            { return GridImplementationFactory.gridSelectionRange(this.controller.gridController) }
 
   private get _gridEvents() { return this.controller.gridEvents } 
 

--- a/projects/ngx-grid-core/src/lib/controller/selection/operations/get-final-selection.operation.ts
+++ b/projects/ngx-grid-core/src/lib/controller/selection/operations/get-final-selection.operation.ts
@@ -23,6 +23,6 @@ export class GetFinalSelection extends BaseSelectionOperation {
   }
 
   private get _selection()  : IGridSelectionRange { return this.controller.gridEvents.CellSelectionChangedEvent.state ?? this._newSelection() }
-  private _newSelection()   : IGridSelectionRange { return GridImplementationFactory.gridSelectionRange(this.controller.gridEvents) }
+  private _newSelection()   : IGridSelectionRange { return GridImplementationFactory.gridSelectionRange(this.controller.gridController) }
 
 }

--- a/projects/ngx-grid-core/src/lib/controller/selection/operations/move-selection-from-focus.operation.ts
+++ b/projects/ngx-grid-core/src/lib/controller/selection/operations/move-selection-from-focus.operation.ts
@@ -40,7 +40,7 @@ export class MoveSelectionFromFocus extends BaseSelectionOperation {
 
     if (!this._hasModifiers) {
 
-      state = new GridSelectionStateFromCoordinates( ...coordinates, this.controller.gridEvents, {
+      state = new GridSelectionStateFromCoordinates( ...coordinates, this.controller.gridController, {
         focusedCell: this._focusedCell,
         previousSelection: this.selectionState?.previousSelection?.clone()
       }, this._hasModifiers, this._hasModifiers)
@@ -60,7 +60,7 @@ export class MoveSelectionFromFocus extends BaseSelectionOperation {
       const prevSelection = state.previousSelection
       if (!prevSelection) return
 
-      prevSelection.secondarySelection = GridImplementationFactory.gridSelectionRange(this.controller.gridEvents).addRange(...coordinates)
+      prevSelection.secondarySelection = GridImplementationFactory.gridSelectionRange(this.controller.gridController).addRange(...coordinates)
 
       const finalSelection = state.currentSelection.clone()
 

--- a/projects/ngx-grid-core/src/lib/controller/selection/operations/preselect-rows.operation.ts
+++ b/projects/ngx-grid-core/src/lib/controller/selection/operations/preselect-rows.operation.ts
@@ -17,7 +17,7 @@ export class PreselectRows {
     const startPos = new GridCellCoordinates(rowKeys[0], firstCol.columnKey)
     const endPos   = new GridCellCoordinates(rowKeys[0], lastCol.columnKey)
 
-    const state = new GridSelectionStateFromCoordinates(startPos, endPos, this.controller.gridEvents)
+    const state = new GridSelectionStateFromCoordinates(startPos, endPos, this.controller.gridController)
 
     this.controller.state = state
 

--- a/projects/ngx-grid-core/src/lib/controller/selection/operations/select-row.operation.ts
+++ b/projects/ngx-grid-core/src/lib/controller/selection/operations/select-row.operation.ts
@@ -9,7 +9,7 @@ export class SelectRow {
 
   public run(rowKey: TPrimaryKey) {
 
-    const utils = GridImplementationFactory.gridSelectionRange(this.controller.gridEvents).globalUtils
+    const utils = GridImplementationFactory.gridSelectionRange(this.controller.gridController).globalUtils
     
     const startPos = new GridCellCoordinates(rowKey, utils.getFirstColumn().columnKey)
     const endPos   = new GridCellCoordinates(rowKey, utils.getLastColumn().columnKey)

--- a/projects/ngx-grid-core/src/lib/controller/selection/state-generators/grid-selection-state-from-coordinates.class.ts
+++ b/projects/ngx-grid-core/src/lib/controller/selection/state-generators/grid-selection-state-from-coordinates.class.ts
@@ -1,4 +1,3 @@
-import { IGridEventsFactory } from '../../../events/grid-events.service'
 import { ESelectMode } from '../../../typings/enums/select-mode.enum'
 import { ESelectionType } from '../../../typings/enums/selection-type.enum'
 import {
@@ -9,6 +8,7 @@ import {
   IGridSelectionState,
 } from '../../../typings/interfaces'
 import { GridImplementationFactory } from '../../../typings/interfaces/implementations/grid-implementation.factory'
+import { GridControllerService } from '../../grid-controller.service'
 
 export class GridSelectionStateFromCoordinates implements IGridSelectionState {
 
@@ -20,16 +20,16 @@ export class GridSelectionStateFromCoordinates implements IGridSelectionState {
   public mode              : ESelectMode          = ESelectMode.Add
 
   constructor(
-    public  startCellPos   : IGridCellCoordinates,
-    public  endCellPos     : IGridCellCoordinates,
-    private readonly events: IGridEventsFactory,
-    input? : Partial<IGridSelectionState>,
-    private _ctrlKey       : boolean = false,
-    private _shiftKey      : boolean = false,
+    public   startCellPos: IGridCellCoordinates,
+    public   endCellPos  : IGridCellCoordinates,
+    readonly controller  : GridControllerService,
+             input?      : Partial<IGridSelectionState>,
+    private  _ctrlKey    : boolean = false,
+    private  _shiftKey   : boolean = false,
   ) {
     Object.assign(this, input)
 
-    this.initialSelection = input?.initialSelection || GridImplementationFactory.gridSelectionRange(this.events)
+    this.initialSelection = input?.initialSelection || GridImplementationFactory.gridSelectionRange(controller)
     this.currentSelection = this.initialSelection.clone()
 
   }

--- a/projects/ngx-grid-core/src/lib/controller/selection/strategies/multi-row.selection-strategy.ts
+++ b/projects/ngx-grid-core/src/lib/controller/selection/strategies/multi-row.selection-strategy.ts
@@ -113,7 +113,7 @@ export class MultiRowSelectionStrategy implements IGridSelectionStrategy {
           new GridCellCoordinates(rowKey, utils.getFirstColumn().columnKey),
           new GridCellCoordinates(rowKey, utils.getLastColumn().columnKey)]
 
-        let nextState = new GridSelectionStateFromCoordinates(...coords, this.controller.gridEvents, {
+        let nextState = new GridSelectionStateFromCoordinates(...coords, this.controller.gridController, {
           initialSelection : this._getSelection(),
           focusedCell      : this._getFocusedCell(),
           previousSelection: this.controller.state.previousSelection
@@ -148,7 +148,7 @@ export class MultiRowSelectionStrategy implements IGridSelectionStrategy {
   )
 
   private _getSelection(): IGridSelectionRange        {
-    return this._getPreviousSelection() ?? GridImplementationFactory.gridSelectionRange(this.controller.gridEvents)
+    return this._getPreviousSelection() ?? GridImplementationFactory.gridSelectionRange(this.controller.gridController)
   }
   
   private _getFocusedCell() { 

--- a/projects/ngx-grid-core/src/lib/controller/transform-pipeline/transform-pipeline.abstract.ts
+++ b/projects/ngx-grid-core/src/lib/controller/transform-pipeline/transform-pipeline.abstract.ts
@@ -29,6 +29,8 @@ export abstract class TransformPipeline<T> {
   private _newTransformers = new Set<Transformer<T>>()
   private _transformerAdded = new Subject<void>()
 
+  private _transformNames = new Set<string>()
+
   constructor() {
 
     // subscribe to the reprocess subject and reprocess the pipeline from the transformation that was touched onwards
@@ -91,6 +93,7 @@ export abstract class TransformPipeline<T> {
       .pipe(takeUntil(transformation.destroyed))
       .subscribe(() => this._reProcess.next(transformation))
 
+    this._transformNames.add(transformation.name)
     this._newTransformers.add(transformation)
     this._transformerAdded.next()
   }
@@ -108,7 +111,12 @@ export abstract class TransformPipeline<T> {
     if (this._tail === transformation) {
       this._tail = prev
     }
+    this._transformNames.delete(transformation.name)
     if (next) this._reProcess.next(next)
+  }
+
+  public hasTransform(name: string) {
+    return this._transformNames.has(name)
   }
 
   public reset (data: T[] = []) {

--- a/projects/ngx-grid-core/src/lib/grid-data-source.ts
+++ b/projects/ngx-grid-core/src/lib/grid-data-source.ts
@@ -132,6 +132,19 @@ export class GridDataSource implements IGridDataSource {
     this._rowMap.set(row.rowKey, row)
   }
 
+  public upsertRows(rows: IGridRow[]) {
+    for (const row of rows) {
+      const existingRow = this.getRow(row.rowKey)
+      if (existingRow) {
+        for (const [key, val] of row.values) {
+          existingRow.setValue(key, val.value)
+        }
+      } else {
+        this.insertNewRows(row)
+      }
+    }
+  }
+
   public insertNewRows(rows: IGridRow[]): void
   public insertNewRows(...rows: IGridRow[]): void
   public insertNewRows(index: number, ...rows: IGridRow[]): void

--- a/projects/ngx-grid-core/src/lib/typings/interfaces/grid-column.interface.ts
+++ b/projects/ngx-grid-core/src/lib/typings/interfaces/grid-column.interface.ts
@@ -1,3 +1,6 @@
+import { ComponentType } from '@angular/cdk/portal'
+import { BehaviorSubject } from 'rxjs'
+
 import { IGridMetadataCollection as IGridMetadataCollection } from '.'
 import { IGridDataType } from './grid-data-type.interface'
 import { IGridSeparator } from './grid-separator.interface'
@@ -9,5 +12,19 @@ export interface IGridColumn {
   sortOrder? : number
   separators?: IGridSeparator[]
   metadata   : IGridMetadataCollection
+  dropdownMenu?: {
+    iconVisibility: BehaviorSubject<EColumnIconVisibility>
+    icon: BehaviorSubject<string>
+    component: ComponentType<IGridColumnDropdownMenuComponent>
+  }
   clone(): IGridColumn
+}
+
+export enum EColumnIconVisibility {
+  OnHover,
+  Always,
+}
+
+export interface IGridColumnDropdownMenuComponent {
+  column: IGridColumn | undefined
 }

--- a/projects/ngx-grid-core/src/lib/typings/interfaces/grid-data-source.interface.ts
+++ b/projects/ngx-grid-core/src/lib/typings/interfaces/grid-data-source.interface.ts
@@ -25,13 +25,14 @@ export interface IGridDataSource extends IDestroyable {
   leafLevel        : number
 
   getRow               (key: TPrimaryKey)                        : IGridRow | undefined
-  setRows              (rows: IGridRow[], subset?: boolean)      : void
+  setRows              (rows: IGridRow[])                        : void
   addRow               (row: IGridRow)                           : void
   getColumn            (key: TColumnKey)                         : IGridColumn | undefined
   hasColumnSubset      ()                                        : boolean
-  getUnderlyingColumns ()                                         : IGridColumn[]
+  getUnderlyingColumns ()                                        : IGridColumn[]
   setColumns           (columns: IGridColumn[], subset?: boolean): void
   clearColumnSubset    ()                                        : void
+  upsertRows           (rows: IGridRow[])                        : void
   insertNewRows        (rows: IGridRow[])                        : void
   insertNewRows        (...rows: IGridRow[])                     : void
   insertNewRows        (index: number, ...rows: IGridRow[])      : void

--- a/projects/ngx-grid-core/src/lib/typings/interfaces/implementations/grid-column.implementation.ts
+++ b/projects/ngx-grid-core/src/lib/typings/interfaces/implementations/grid-column.implementation.ts
@@ -1,4 +1,7 @@
-import { IGridColumn, IGridDataType, IGridMetadataCollection, IGridSeparator } from '..'
+import { ComponentType } from '@angular/cdk/portal'
+import { BehaviorSubject } from 'rxjs'
+
+import { EColumnIconVisibility, IGridColumn, IGridDataType, IGridMetadataCollection, IGridSeparator } from '..'
 import { TColumnKey } from '../../types'
 import { GridImplementationFactory } from './grid-implementation.factory'
 
@@ -9,6 +12,12 @@ export class GridColumn implements IGridColumn {
   public sortOrder? : number
   public separators?: IGridSeparator[]
   public metadata   : IGridMetadataCollection
+
+  public dropdownMenu?: {
+    icon: BehaviorSubject<string>
+    component: ComponentType<any>,
+    iconVisibility: BehaviorSubject<EColumnIconVisibility>
+  }
 
   constructor(public readonly columnKey: TColumnKey) {
     this.metadata = GridImplementationFactory.gridMetadataCollection()

--- a/projects/ngx-grid-core/src/lib/typings/interfaces/implementations/grid-implementation.factory.ts
+++ b/projects/ngx-grid-core/src/lib/typings/interfaces/implementations/grid-implementation.factory.ts
@@ -10,7 +10,7 @@ import {
   IGridRow,
   IGridSelectionRange,
 } from '..'
-import { IGridEventsFactory } from '../../../events/grid-events.service'
+import { GridControllerService } from '../../../controller/grid-controller.service'
 import { EGridStyle } from '../../../styles/grid-style.enum'
 import { GridStyle } from '../../../styles/grid-style.implementation'
 import { TColumnKey, TPrimaryKey, TRowValues } from '../../types'
@@ -25,10 +25,10 @@ export class GridImplementationFactory {
   public static gridColumn             = (columnKey: TColumnKey)                             : IGridColumn             => new GridColumn(columnKey)
   public static gridStyle              = (style: EGridStyle)                                 : IGridStyle              => new GridStyle(style)
 
-  public static gridSelectionRange = (gridEvents: IGridEventsFactory,
+  public static gridSelectionRange = (controller: GridControllerService,
     input?: Partial<IGridSelectionRange>,
     rowMap?: Map<TPrimaryKey, Set<TColumnKey>>,
     colMap?: Map<TColumnKey, Set<TPrimaryKey>>
-  ): IGridSelectionRange => new GridSelectionRange(gridEvents, input, rowMap, colMap)
+  ): IGridSelectionRange => new GridSelectionRange(controller, input, rowMap, colMap)
 
 }

--- a/projects/ngx-grid-core/src/lib/ui/body/body.component.ts
+++ b/projects/ngx-grid-core/src/lib/ui/body/body.component.ts
@@ -1,7 +1,7 @@
 import { CdkVirtualScrollViewport } from '@angular/cdk/scrolling'
 import { ChangeDetectionStrategy, ChangeDetectorRef, Component, Input, OnInit, ViewChild } from '@angular/core'
 import { concat, interval } from 'rxjs'
-import { distinctUntilChanged, map, switchMap, take } from 'rxjs/operators'
+import { distinctUntilChanged, map, startWith, switchMap, take } from 'rxjs/operators'
 
 import { GridControllerService } from '../../controller/grid-controller.service'
 import { GridEventsService } from '../../events/grid-events.service'
@@ -56,17 +56,14 @@ export class BodyComponent extends AutoUnsubscribe implements OnInit {
     let isFirstRows = true
 
     this.addSubscription(dataSourceChanges
-      .pipe(switchMap(source => source.rows.output))
+      .pipe(startWith(this.gridController.dataSource), switchMap(source => source.rows.output))
       .subscribe(rows => {
-          if (!rows.length && !isFirstRows) {
-            return
-          }
-          if (isFirstRows) {
+          if (isFirstRows && rows.length) {
             // if this is the first time we've seen rows
             // then reset grid initialisation state so column widths are calculated
             this.events.factory.GridInitialisedEvent.emit(false)
+            isFirstRows = false
           }
-          isFirstRows = false
           this.rows = rows
           this.cd.detectChanges()}))
 

--- a/projects/ngx-grid-core/src/lib/ui/cell/cell-types/date.cell-type.ts
+++ b/projects/ngx-grid-core/src/lib/ui/cell/cell-types/date.cell-type.ts
@@ -54,7 +54,7 @@ export class DateCellType extends BaseCellType {
   }
 
   private get _displayValue(): string {
-    return this.gridController.cell.GetFormattedValue.run(this.coordinates, this.value)
+    return this.gridController.cell.GetFormattedValue.getHTML(this.coordinates, this.value)
   }
 
 }

--- a/projects/ngx-grid-core/src/lib/ui/cell/cell-types/number.cell-type.ts
+++ b/projects/ngx-grid-core/src/lib/ui/cell/cell-types/number.cell-type.ts
@@ -53,7 +53,7 @@ export class NumberCellType extends BaseCellType {
     let val: number = typeof this.value === 'number' ? this.value : parseFloat(this.value)
     const formatString = this.gridController.cell.GetCellMetaValue.run<string>(this.coordinates, EMetadataType.NumberFormatString)
     if (formatString !== null) {
-      return this.gridController.cell.GetFormattedValue.run(this.coordinates, val)
+      return this.gridController.cell.GetFormattedValue.getHTML(this.coordinates, val)
     } else {
       return val.toString()
     }

--- a/projects/ngx-grid-core/src/lib/ui/cell/cell.component.ts
+++ b/projects/ngx-grid-core/src/lib/ui/cell/cell.component.ts
@@ -78,7 +78,9 @@ export class CellComponent extends AutoUnsubscribe implements OnInit, AfterViewC
 
   public detectChanges = () => {
     this.renderCellType()
-    this.typeComponent?.receiveValue(this._getValue())
+    if (this._getValue() !== this.typeComponent?.value) {  
+      this.typeComponent?.receiveValue(this._getValue())
+    }
 
     const tooltip = this.gridController.cell.GetCellMeta.run(this.coordinates).metadata.get<string>(EMetadataType.ToolTip)
 

--- a/projects/ngx-grid-core/src/lib/ui/grid-overlays/single-select-grid-dropdown-overlay/single-select-grid-dropdown-overlay.component.ts
+++ b/projects/ngx-grid-core/src/lib/ui/grid-overlays/single-select-grid-dropdown-overlay/single-select-grid-dropdown-overlay.component.ts
@@ -3,6 +3,7 @@ import { FormControl } from '@angular/forms'
 import { fromEvent } from 'rxjs'
 
 import { DataGridConfigs } from '../../../data-grid-configs.class'
+import { GridDataSource } from '../../../grid-data-source'
 import { GRID_OVERLAY_DATA } from '../../../services/grid-overlay-service.service'
 import { EGridOverlayType } from '../../../typings/enums/grid-overlay-type.enum'
 import { IGridDataSource, IGridOverlayData, IGridSelectionSlice } from '../../../typings/interfaces'
@@ -85,7 +86,12 @@ export class SingleSelectGridDropdownOverlayComponent extends BaseOverlayCompone
   private _getDataSource(): IGridDataSource | undefined {
     const gridID = this.data.currentCell?.type.list?.relatedGridID
     if (!gridID) return undefined
-    return this.gridController.grid.GetRelatedData.run(gridID)
+    let source = this.gridController.grid.GetRelatedData.run(gridID)
+    if (source) {
+      // clone the source to avoid changing the original
+      source = GridDataSource.cloneSource(source)
+    }  
+    return source
   }
 
 }

--- a/projects/ngx-grid-core/src/lib/ui/header/header.component.html
+++ b/projects/ngx-grid-core/src/lib/ui/header/header.component.html
@@ -12,10 +12,22 @@
     *ngFor="let column of (columns | async); let index = index"
     [style.width] = "((columnWidths | async)?.[column.columnKey] ?? '') + 'px'"
     class="cell display">
-    <app-resizer (output)="resizeColumn($event.x, column)" (resizeStart)="startResize()"
-      (resizeEnd)="endResize()" (mouseenter)="disableDrag()" (mouseleave)="enableDrag()"></app-resizer>
-    <span class="material-symbols-outlined sort-icon" *ngIf="columnHasSort(column)">{{ columnSortIconKey(column) }}</span>
-    <data-grid-separator *ngFor="let s of separators(column.columnKey)" Axis="y" [separator]="s"></data-grid-separator>
-    <div class="text-readonly"><lib-localized-text>{{ column.name ?? column.columnKey }}</lib-localized-text></div>
-    </div>
+      <app-resizer (output)="resizeColumn($event.x, column)" (resizeStart)="startResize()"
+        (resizeEnd)="endResize()" (mouseenter)="disableDrag()" (mouseleave)="enableDrag()"></app-resizer>
+      <span class="material-symbols-outlined sort-icon" *ngIf="columnHasSort(column)">{{ columnSortIconKey(column) }}</span>
+      <data-grid-separator *ngFor="let s of separators(column.columnKey)" Axis="y" [separator]="s"></data-grid-separator>
+      <div class="text-readonly"><lib-localized-text>{{ column.name ?? column.columnKey }}</lib-localized-text></div>
+      <button mat-icon-button class="col-dropdown-btn" *ngIf="column.dropdownMenu"
+        (mousedown)="$event.stopPropagation()"
+        (click)="$event.stopPropagation(); openMenu(column)"
+        [matMenuTriggerFor]="columnMenu"
+        #columnMenuTrigger="matMenuTrigger"
+        (menuClosed)="columnMenuContainerRef?.clear()"
+        [ngClass]="{ menuOpen: columnMenuTrigger.menuOpen, keepIconVisible: (column.dropdownMenu.iconVisibility | async) === iconVisibility.Always }">
+          <mat-icon [ngClass]="{thinLine: isThinlineIcon(column.dropdownMenu.icon | async)}" [svgIcon]="(column.dropdownMenu.icon | async) ?? ''"></mat-icon>
+      </button>
+  </div>
+  <mat-menu #columnMenu="matMenu" [hasBackdrop]="false" class="column-menu">
+    <ng-template #columnMenuTemplate></ng-template>
+  </mat-menu>
 </div>

--- a/projects/ngx-grid-core/src/lib/ui/header/header.component.html
+++ b/projects/ngx-grid-core/src/lib/ui/header/header.component.html
@@ -23,7 +23,7 @@
         [matMenuTriggerFor]="columnMenu"
         #columnMenuTrigger="matMenuTrigger"
         (menuClosed)="columnMenuContainerRef?.clear()"
-        [ngClass]="{ menuOpen: columnMenuTrigger.menuOpen, keepIconVisible: (column.dropdownMenu.iconVisibility | async) === iconVisibility.Always }">
+        [ngClass]="{ keepIconVisible: (column.dropdownMenu.iconVisibility | async) === iconVisibility.Always }">
           <mat-icon [ngClass]="{thinLine: isThinlineIcon(column.dropdownMenu.icon | async)}" [svgIcon]="(column.dropdownMenu.icon | async) ?? ''"></mat-icon>
       </button>
   </div>

--- a/projects/ngx-grid-core/src/lib/ui/header/header.component.scss
+++ b/projects/ngx-grid-core/src/lib/ui/header/header.component.scss
@@ -4,13 +4,16 @@
   margin-right: -9999999px;
   position: relative;
   z-index: 1;
+
   .cell {
     user-select: none;
     cursor: pointer;
+
     &:hover:not(.row-thumb) {
       background-color: var(--highlight-color);
     }
   }
+
   .Dragging {
     .cell {
       cursor: move;
@@ -25,4 +28,44 @@
   font-size: 15px;
   margin-left: 1px;
   margin-right: -7px;
+}
+
+button.col-dropdown-btn {
+  width: 24px;
+  height: 24px;
+  line-height: 24px;
+
+  &:not(.menuOpen):not(.keepIconVisible) {
+    opacity: 0;
+  }
+
+  svg,
+  .mat-icon {
+    width: 12px;
+    height: 12px;
+    line-height: 12px;
+    opacity: 0.8;
+
+    &.thinLine {
+      stroke: currentColor;
+      stroke-width: 2px;
+    }
+
+    &:hover {
+      opacity: 1;
+    }
+  }
+}
+
+.cell:hover {
+  button.col-dropdown-btn {
+    opacity: 1;
+  }
+}
+
+::ng-deep {
+  .mat-menu-panel.column-menu {
+    background-color: var(--app-bg);
+    margin-top: 1px;
+  }
 }

--- a/projects/ngx-grid-core/src/lib/ui/header/header.component.scss
+++ b/projects/ngx-grid-core/src/lib/ui/header/header.component.scss
@@ -35,7 +35,7 @@ button.col-dropdown-btn {
   height: 24px;
   line-height: 24px;
 
-  &:not(.menuOpen):not(.keepIconVisible) {
+  &:not(.keepIconVisible) {
     opacity: 0;
   }
 


### PR DESCRIPTION
- Added overloads to getFormatedValueOperation to accept cell coordinates or a column as the first argument
- Added method on grid controller to get the default date format
- Added an internal property to TransformPipeline to track transforms and exposed hasTransform() to check if the transform is already a part of the pipeline 
- Fixed the filterRowsOperation so it actually works with the row transform pipeline and it filters on formatted values now
- Changed GridSelectionRange to accept grid controller instead of grid events in its constructor
- Added a method to grid data source to upsert rows for handling delta changes
- Added dropdownMenu parameters to IGridColumnInterface and implementation
- Fixed a bug in the body component where records would not show if they were provided before the component was initialized
- Optimized cell component detectChanges() to only receive the value into the cell type if it is different from the currrent value
- Now cloning the original data source in SingleSelectGridDropdownOverlayComponent as we need the row pipeline to be distinct
- Added grid dropdown menu to the HeaderComponent