### PR TITLE
Changes to ensure column header width is auto set based on localized text

### DIFF
--- a/projects/ngx-grid-core/package-lock.json
+++ b/projects/ngx-grid-core/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ngx-grid-core",
-  "version": "0.16.2",
+  "version": "0.16.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ngx-grid-core",
-      "version": "0.16.2",
+      "version": "0.16.3",
       "dependencies": {
         "tslib": "^2.3.0"
       },

--- a/projects/ngx-grid-core/package.json
+++ b/projects/ngx-grid-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blueshiftone/ngx-grid-core",
-  "version": "0.16.2",
+  "version": "0.16.3",
   "repository": {
     "type": "git",
     "url": "https://github.com/blueshiftone/ngx-grid",

--- a/projects/ngx-grid-core/src/lib/grid-data-source.ts
+++ b/projects/ngx-grid-core/src/lib/grid-data-source.ts
@@ -42,6 +42,7 @@ export class GridDataSource implements IGridDataSource {
   public disabled         = false
   public maskNewIds       = false
   public leafLevel        = -1
+  public localizations    = undefined
 
   public relatedData: Map<string, IGridDataSource> = new Map()
   public cellMeta   : Map<string, IGridCellMeta>   = new Map()

--- a/projects/ngx-grid-core/src/lib/services/localization.service.ts
+++ b/projects/ngx-grid-core/src/lib/services/localization.service.ts
@@ -22,8 +22,8 @@ export class LocalizationService {
   constructor(
     private readonly prefs : LocalPreferencesService,
   ) {
-    for (const entry of GRID_LOCALIZATION_DEFAULTS.entries()) {
-      this._defaultLocMap.set(entry[0], entry[1])
+    for (const [key, val] of GRID_LOCALIZATION_DEFAULTS.entries()) {
+      this._defaultLocMap.set(key, val)
     }
   }
 

--- a/projects/ngx-grid-core/src/lib/typings/interfaces/grid-data-source.interface.ts
+++ b/projects/ngx-grid-core/src/lib/typings/interfaces/grid-data-source.interface.ts
@@ -2,6 +2,7 @@ import { Observable } from 'rxjs'
 
 import { IGridCellMeta, IGridColumn, IGridMetadataCollection } from '.'
 import { RowPipeline } from '../../controller/transform-pipeline/row-pipeline'
+import { ILocalization } from '../../services/localization.service'
 import { TColumnKey, TPrimaryKey } from '../types'
 import { IDestroyable } from './destroyable.interface'
 import { IGridRow } from './grid-row.interface'
@@ -23,6 +24,7 @@ export interface IGridDataSource extends IDestroyable {
   maskNewIds       : boolean
   metadata         : IGridMetadataCollection
   leafLevel        : number
+  localizations?   : ILocalization[]
 
   getRow               (key: TPrimaryKey): IGridRow | undefined
   setRows              (rows: IGridRow[]): void

--- a/projects/ngx-grid-core/src/lib/ui/data-grid/data-grid.component.ts
+++ b/projects/ngx-grid-core/src/lib/ui/data-grid/data-grid.component.ts
@@ -85,6 +85,8 @@ export class DataGridComponent extends AutoUnsubscribe implements OnInit, OnChan
     if (this._parentIsStatic) this._parentEl.style.position = 'relative'
 
     this.gridController.grid.SetDataSource.run(this.data)
+
+    if (this.data.localizations) this.localizations.setLocalizations(this.data.localizations)
     
     this._afterGridInit(() => {
       this.initialised = true

--- a/projects/ngx-grid-core/src/lib/ui/header/header.component.ts
+++ b/projects/ngx-grid-core/src/lib/ui/header/header.component.ts
@@ -167,11 +167,8 @@ export class HeaderComponent extends AutoUnsubscribe implements OnInit {
       this.columns.next(nextColumns)
     }
 
-    let additionalWidth = 20
+    const additionalWidth = 35
     this.columns.value.forEach(v => {
-      if (this.currentSortOrder(v) !== ESortDirection.Natural) {
-        additionalWidth += 15
-      }
       const formattedValue = this.loc.getLocalizedString(v.name ?? v.columnKey)
       this.gridController.column.InitialiseColumnWidth.bufferHeaderCellWidth([v.columnKey, CharacterSizer.measure(formattedValue, this._getFont()) + additionalWidth])
     })


### PR DESCRIPTION
- Changes to ensure column header width is auto set based on localized text (with localizations sourced from grid data source on init).
- Increased additional width for column header so that column header text is fully displayed regardless of whether sort direction icon is displayed or not.