### PR TITLE
Fix grid ids, integer handling and percentage scaling

### DIFF
--- a/projects/ngx-grid-core/package-lock.json
+++ b/projects/ngx-grid-core/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ngx-grid-core",
-  "version": "0.17.2",
+  "version": "0.17.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ngx-grid-core",
-      "version": "0.17.2",
+      "version": "0.17.3",
       "dependencies": {
         "tslib": "^2.3.0"
       },

--- a/projects/ngx-grid-core/package.json
+++ b/projects/ngx-grid-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blueshiftone/ngx-grid-core",
-  "version": "0.17.2",
+  "version": "0.17.3",
   "repository": {
     "type": "git",
     "url": "https://github.com/blueshiftone/ngx-grid",

--- a/projects/ngx-grid-core/src/lib/controller/grid-operations/grid-paste.operation.ts
+++ b/projects/ngx-grid-core/src/lib/controller/grid-operations/grid-paste.operation.ts
@@ -151,9 +151,8 @@ export class GridPaste extends Operation {
 
         let index = visibleRows.length
         for (const row of newRows) {
-          const { rowKey } = row
           dataSource.insertNewRows(row)
-          this.rowOperations.SetRowStatus.buffer(rowKey, ERowStatus.New)
+          this.rowOperations.SetRowStatus.run(row, ERowStatus.New)
           index++
         }
         

--- a/projects/ngx-grid-core/src/lib/controller/row-operations/add-row.operation.ts
+++ b/projects/ngx-grid-core/src/lib/controller/row-operations/add-row.operation.ts
@@ -26,9 +26,9 @@ export class AddRow extends Operation {
       const [row, atIndex] = arg
       rowKey = row.rowKey
 
+      this.rowOperations.SetRowStatus.run(row, ERowStatus.New)
+      
       this.dataSource.insertNewRows(atIndex ?? -1, row)
-
-      buffers.add(this.rowOperations.SetRowStatus.buffer(rowKey, ERowStatus.New))
       
       for (const column of this.dataSource.columns) {
         const isEditable = this.cellOperations.GetCellIsEditable.run(new GridCellCoordinates(rowKey, column.columnKey))

--- a/projects/ngx-grid-core/src/lib/controller/row-operations/delete-row.operation.ts
+++ b/projects/ngx-grid-core/src/lib/controller/row-operations/delete-row.operation.ts
@@ -33,7 +33,7 @@ export class DeleteRow extends Operation {
         if (WithDefaultTrue(options.emitEvent) === true) this.gridEvents.RowDeletedEvent.emit(rowKey)
 
       } else {
-        promises.add(this.rowOperations.SetRowStatus.buffer(rowKey, ERowStatus.Deleted, { emitEvent: options.emitEvent }))
+        this.rowOperations.SetRowStatus.run(rowKey, ERowStatus.Deleted, { emitEvent: options.emitEvent })
       }
 
       const rowComponent = this.rowOperations.RowComponents.findWithPrimaryKey(rowKey)

--- a/projects/ngx-grid-core/src/lib/controller/row-operations/reset-row-status.operation.ts
+++ b/projects/ngx-grid-core/src/lib/controller/row-operations/reset-row-status.operation.ts
@@ -30,7 +30,7 @@ export class ResetRowStatus extends Operation {
 
       if (hasDraftValue) status = ERowStatus.Draft
 
-      promises.add(this.rowOperations.SetRowStatus.buffer(rowKey, status))
+      this.rowOperations.SetRowStatus.run(rowKey, status)
     }
 
     await Promise.all(promises)

--- a/projects/ngx-grid-core/src/lib/controller/row-operations/set-row-status.operation.ts
+++ b/projects/ngx-grid-core/src/lib/controller/row-operations/set-row-status.operation.ts
@@ -40,13 +40,17 @@ export class SetRowStatus extends Operation {
 
   private async _bufferEvents(args: [IGridRow][]) {
     const primaryKeys = new Set<TPrimaryKey>()
-    
-    for (const arg of args) {
-      let [row] = arg
-      primaryKeys.add(row.rowKey)
+    const rows: IGridRow[] = []
+
+    for (const [row] of args) {
+      if (!primaryKeys.has(row.rowKey) && this.dataSource.getRow(row.rowKey) !== undefined) {
+        rows.push(row.clone())
+        primaryKeys.add(row.rowKey)
+      }
     }
-    this.gridEvents.GridWasModifiedEvent.emit(true) 
-    this.gridEvents.RowStatusChangedEvent.emit([...primaryKeys].map(pk => this.dataSource.getRow(pk)).filter(meta => meta).map(m => m?.clone()) as IGridRow[])
+
+    this.gridEvents.GridWasModifiedEvent.emit(true)
+    this.gridEvents.RowStatusChangedEvent.emit(rows)
   }
 }
 

--- a/projects/ngx-grid-core/src/lib/typings/interfaces/number-options.interface.ts
+++ b/projects/ngx-grid-core/src/lib/typings/interfaces/number-options.interface.ts
@@ -1,4 +1,5 @@
 export interface INumberOptions {
   formatString?: string
   scaleFactor?: number
+  maxDecimalPlaces?: number
 }

--- a/projects/ngx-grid-core/src/lib/ui/cell/cell-types/abstractions/base-cell-type.abstract.ts
+++ b/projects/ngx-grid-core/src/lib/ui/cell/cell-types/abstractions/base-cell-type.abstract.ts
@@ -63,7 +63,7 @@ export abstract class BaseCellType implements IGridCellType {
     if (value === '') value = null
     let validationResult = this.gridController.cell.SetCellValue.run(this.coordinates, value)
     if (validationResult.isValid) {
-      this.receiveValue(value)
+      this.receiveValue(validationResult.transformedValue)
       this.gridController.cell.SetCellDraftValue.buffer(this.coordinates)
     }
     return validationResult.isValid

--- a/projects/ngx-grid-core/src/lib/ui/cell/cell-types/value-parsing/parsers/number.parser.ts
+++ b/projects/ngx-grid-core/src/lib/ui/cell/cell-types/value-parsing/parsers/number.parser.ts
@@ -41,7 +41,7 @@ export class NumberParser extends BaseParser implements IParsingTest {
 
       if (Number.isNaN(transformedValue)) return this.failed()
 
-      if (this.initialValue.includes('%')) transformedValue /= 10
+      if (this.initialValue.includes('%')) transformedValue /= 100
 
       return this.passed(transformedValue)
 

--- a/projects/ngx-grid-core/src/lib/ui/cell/cell-types/value-parsing/parsers/number.parser.ts
+++ b/projects/ngx-grid-core/src/lib/ui/cell/cell-types/value-parsing/parsers/number.parser.ts
@@ -1,5 +1,5 @@
-import { EMetadataType } from '../../../../../typings/enums'
 import { GridControllerService } from '../../../../../controller/grid-controller.service'
+import { EMetadataType } from '../../../../../typings/enums'
 import { IGridCellCoordinates, IGridValueParsingResult, INumberOptions } from '../../../../../typings/interfaces'
 import { TAtLeast } from '../../../../../typings/types/at-least.type'
 import { BaseParser } from './base-parser.abstract'
@@ -42,9 +42,8 @@ export class NumberParser extends BaseParser implements IParsingTest {
       
       // Truncate decimals to max number of places
       const numberOptions = gridController?.dataSource.getColumn(cellCoords?.columnKey ?? '')?.metadata?.get<INumberOptions>(EMetadataType.NumberOptions)
-      if (numberOptions) {
-        const maxDecimalPlaces = (numberOptions.maxDecimalPlaces ?? 0) + (this.initialValue.includes('%') ? 2 : 0)
-        if (decimals && decimals.length > maxDecimalPlaces) decimals = decimals.slice(0, maxDecimalPlaces)
+      if (numberOptions?.maxDecimalPlaces !== undefined && decimals && decimals.length > numberOptions.maxDecimalPlaces) {
+        decimals = decimals.slice(0, numberOptions.maxDecimalPlaces)
       }
 
       let transformedValue = parseFloat(`${integer}${typeof decimals !== 'undefined' ? `.${decimals}` : ``}`)


### PR DESCRIPTION
Fixes: 
- GUID ids for new rows were not hidden
- Numbers can now define a maxDecimalPlaces to prevent returning decimal values where an integer is expected
- Fixed scaling when the number parser encountered a percentage