### PR TITLE
Bugfixes in Paste Operation

### DIFF
--- a/projects/ngx-grid-core/package-lock.json
+++ b/projects/ngx-grid-core/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ngx-grid-core",
-  "version": "0.19.3",
+  "version": "0.19.4",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ngx-grid-core",
-      "version": "0.19.3",
+      "version": "0.19.4",
       "dependencies": {
         "tslib": "^2.3.0"
       },

--- a/projects/ngx-grid-core/package-lock.json
+++ b/projects/ngx-grid-core/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "ngx-grid-core",
-  "version": "0.19.2",
+  "version": "0.19.3",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "ngx-grid-core",
-      "version": "0.19.2",
+      "version": "0.19.3",
       "dependencies": {
         "tslib": "^2.3.0"
       },

--- a/projects/ngx-grid-core/package.json
+++ b/projects/ngx-grid-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blueshiftone/ngx-grid-core",
-  "version": "0.19.2",
+  "version": "0.19.3",
   "repository": {
     "type": "git",
     "url": "https://github.com/blueshiftone/ngx-grid",

--- a/projects/ngx-grid-core/package.json
+++ b/projects/ngx-grid-core/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@blueshiftone/ngx-grid-core",
-  "version": "0.19.3",
+  "version": "0.19.4",
   "repository": {
     "type": "git",
     "url": "https://github.com/blueshiftone/ngx-grid",

--- a/projects/ngx-grid-core/src/lib/utils/get-csv-score.ts
+++ b/projects/ngx-grid-core/src/lib/utils/get-csv-score.ts
@@ -1,5 +1,8 @@
 export function GetCsvScore(data: string, delimiter: string): number {
 
+  // return high score if delimiter is a tab character
+  if (delimiter.match(/\t/)) return 100
+
   let score = 0
 
   let lines = data.split(/\r\n|\n|\r/)


### PR DESCRIPTION
This change fixes two issues:
1. When pasting values out of Excel, plaintext values were derived from parsed HTML. For certain single or multi-select values, addition whitespace and newlines were present in the parsed value. This caused the parsed value to fail the foreign key match and  be discarded when applying the cell values.
2. An incorrect column index value was causing an exception in certain scenarios when pasting new rows (beyond the bounds of the grid)

The fix for the first issue involved relying on plaintext clipboard data and only using HTML to parse HTML values (which is then only used for RichText fields)